### PR TITLE
Bugfix: add missing Bind Scope

### DIFF
--- a/theories/Lens.v
+++ b/theories/Lens.v
@@ -24,6 +24,8 @@ End ops.
 Module LensNotations.
   Declare Scope lens_scope.
   Delimit Scope lens_scope with lens.
+  Bind Scope lens_scope with Lens.
+
   Notation "X -l> Y" := (Lens X X Y Y)
     (at level 99, Y at level 200, right associativity) : type_scope.
   Notation "a & b" := (b a) (at level 50, only parsing, left associativity) : lens_scope.


### PR DESCRIPTION
With this, you should be able to omit `%lens` (in most cases) when the target
type is `Foo -l> Bar`.

Draft, because a bit more testing might be needed before deploying — only tested in a client-side clone of the notation.