### PR TITLE
Support Coq 8.14 and 8.15

### DIFF
--- a/test-suite/demo.v
+++ b/test-suite/demo.v
@@ -5,7 +5,7 @@ Require Import Lens.TC.TC.
 Record Oops : Set :=
 { oops1 : nat }.
 
-Fail Run TemplateProgram (genLens Oops).
+Fail MetaCoq Run (genLens Oops).
 
 Set Primitive Projections.
 
@@ -14,7 +14,7 @@ Record Foo : Set :=
 ; bar : bool }.
 
 
-Run TemplateProgram (genLens Foo).
+MetaCoq Run (genLens Foo).
 
 About _foo.
 About _bar.

--- a/theories/TC/TC.v
+++ b/theories/TC/TC.v
@@ -5,7 +5,7 @@ Local Open Scope string_scope.
 
 From MetaCoq.Template Require Import
      monad_utils Ast Loader TemplateMonad.
-Import MonadNotation.
+Import MCMonadNotation.
 
 Require Import Lens.Lens.
 
@@ -71,7 +71,8 @@ Local Definition getFields (mi : mutual_inductive_body) (n : nat)
     match oib.(ind_ctors) with
     | nil => tmFail "`getFields` got empty type"
     | ctor :: nil =>
-      let '(ctor_name,ctor_type,_) := ctor in
+      let ctor_name := ctor.(cstr_name) in
+      let ctor_type := ctor.(cstr_type) in
       match oib.(ind_projs) with
       | nil =>
         let ctor_arity := get_arity ctor_type in


### PR DESCRIPTION
`make test` passes but I haven't done other testing. I have only looked quickly at `constructor_body` to find how to deconstruct it — here's a copy for convenience:

```coq
  Record constructor_body := {
    cstr_name : ident;
    (* The arguments and indices are typeable under the context of 
      arities of the mutual inductive + parameters *)
    cstr_args : context;
    cstr_indices : list term;
    cstr_type : term; 
    (* Closed type: on well-formed constructors: forall params, cstr_args, I params cstr_indices *)
    cstr_arity : nat; (* arity, w/o lets, w/o parameters *)
  }.
```